### PR TITLE
Replace osapi call for get viewer. Closes #53

### DIFF
--- a/main/ils_graaspeu.js
+++ b/main/ils_graaspeu.js
@@ -28,8 +28,8 @@ requirements: this library uses jquery
             username = $.cookie('graasp_user');
           }
         } else if (context == context_graasp) {
-          osapi.people.getViewer().execute(function(viewer) {
-            username = viewer.displayName;          
+          osapi.people.get({userId: '@viewer'}).execute(function(viewer) {
+            username = viewer.displayName;
           });
         }
 


### PR DESCRIPTION
osapi.people.getViewer() only works if it's executed in the widget itself. To execute the call from the ils library we need to specify  the userId as "@viewer"