### PR TITLE
chore: support for item's 'category' field

### DIFF
--- a/main/ils_graaspeu.js
+++ b/main/ils_graaspeu.js
@@ -562,7 +562,8 @@
 
             var error;
             var filters = {};
-            filters["_type"] = "Space";
+            filters["_type"] = "Space"; // Remove after migration
+            filters["category"] = "Space";
             osapi.spaces.get({contextId: spaceId, contextType: "@space", filters: filters}).execute(function (spaces) {
                 if (!spaces.error && spaces.list) {
                     return cb(spaces.list);
@@ -589,7 +590,8 @@
 
             var error;
             var filters = {};
-            filters["_type"] = "Application";
+            filters["_type"] = "Application"; // Remove after migration
+            filters["category"] = "Application";
             osapi.spaces.get({contextId: spaceId, contextType: "@space", filters: filters}).execute(function (apps) {
                 if (!apps.error && apps.list) {
                     return cb(apps.list);
@@ -651,7 +653,8 @@
             var error;
             if (ilsId && ilsId != "") {
                 var filters = {};
-                filters["_type"] = "Space";
+                filters["_type"] = "Space"; // Remove after migration
+                filters["category"] = "Space";
                 filters["metadata.type"] = "Vault";
                 osapi.spaces.get({contextId: ilsId, contextType: "@space", filters: filters}).execute(function (spaces) {
                     if (!spaces.error && spaces.list) {


### PR DESCRIPTION
this will use both fields ('_type', 'category').
after the graasp.eu migration, references to '_type' need to be removed.

fix #136